### PR TITLE
get os env REBAR_LIB_DEPS dir, used to join internal_otp_vsn.h path name

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -46,10 +46,18 @@ begin
       end,
 
   Data = ["-define(_internal_otp_vsn_", X,$_,Y,$_,Z, ", true).", $\n],
+  
+  DepsDir = case os:getenv("REBAR_LIB_DEPS") of 
+	      false -> "_build/default/lib";
+	      [] -> "_build/default/lib";
+	      Dir -> 
+		Dir
+	    end,
   Dst = case filelib:is_regular(filename:join("src","otp_vsn.app.src")) of
             false ->
                 filename:join(
-                  ["_build","default","lib","otp_vsn","include","internal_otp_vsn.hrl"
+                  %["_build","default","lib","otp_vsn","include","internal_otp_vsn.hrl"
+                  [DepsDir,"otp_vsn","include","internal_otp_vsn.hrl"
                   ]);
             true ->
                 %% Current app is this app itself


### PR DESCRIPTION
When I use rebar.config.script in my project, build will be failed at file:write_file/2.
In error situation:
my rebar.config.script in my app is : 
--------------------------
% vim: set ft=erlang ts=4:

FEnvSubst = fun({Env,Key},Acc)
                when is_list(Env),is_atom(Key),is_list(Acc) ->

                case os:getenv(Env) of
                  false -> Acc ;        % env var not defined
                  [] -> Acc ;           % env var set to empty string
                  Dir ->
                    lists:keystore(Key,1,Acc,{Key,Dir})
                end
            end,

Return = lists:foldl(FEnvSubst,CONFIG,
                                         [
                                          {"REBAR_LIB_DEPS",deps_dir}
                                          ,{"REBAR_PLUGINS_DEPS",plugins_dir}
                                         ]),
io:format("Return=~p~n",[Return]),
Return.
---------------------
Error in otp_vsn's rebar.config.script:
Dst="_build/default/lib/otp_vsn/include/internal_otp_vsn.hrl"
which should be : 
Dst = "/home/simonxu/default/lib/otp_vsn/include/internal_otp_vsn.hrl"

which result file:write_file/2 error: enoent

Currrent patch may be temporary fix only, it should be reviewed and suited for more commen situation while chaning default deps_dir location.

thx.

